### PR TITLE
remove unnecessary slash character

### DIFF
--- a/file.js
+++ b/file.js
@@ -7,7 +7,7 @@ const recipeSelector = () => {
 }
 
 console.log('Before job instantiation');
-var job = new CronJob('* */1 * * *', function() {
+var job = new CronJob('* * * * *', function() {
   console.log(recipeSelector(recipes));
 }, null, true, 'America/Los_Angeles');
 console.log('After job instantiation');

--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,5 +1,5 @@
 {
-  "systemParams": "linux-x64-88",
+  "systemParams": "linux-x64-93",
   "modulesFolders": [
     "node_modules"
   ],


### PR DESCRIPTION
The / character on the "minutes" position means divided.  So technically /1 is redundant and the same as just using the asterisk alone

If you wanted to do "every five minutes" then "'* */5 * * *" would make sense, but for every minute you dont need the /1